### PR TITLE
Move robot left in lateral tuners

### DIFF
--- a/src/localization/threeWheel.md
+++ b/src/localization/threeWheel.md
@@ -18,7 +18,7 @@ Open the file `ThreeWheelLocalizer.java` and configure the following:
 Ensure the following:
 
 * Forward encoder ticks up when the robot moves forward.
-* Strafe encoder ticks up when the robot moves to the right.
+* Strafe encoder ticks up when the robot moves to the left.
 
 ### 3. Localizer Tuning
 

--- a/src/localization/threeWheelImu.md
+++ b/src/localization/threeWheelImu.md
@@ -20,7 +20,7 @@ Open the file `ThreeWheelIMULocalizer.java` and configure the following:
 Ensure the following:
 
 * Forward encoder ticks up when the robot moves forward.
-* Strafe encoder ticks up when the robot moves to the right.
+* Strafe encoder ticks up when the robot moves to the left.
 
 ### 3. Localizer Tuning
 

--- a/src/localization/twoWheel.md
+++ b/src/localization/twoWheel.md
@@ -18,7 +18,7 @@ Open the file `TwoWheelLocalizer.java` and configure the following:
 Ensure the following:
 
 * The forward encoder ticks up when the robot moves forward.
-* The strafe encoder ticks up when the robot moves to the right.
+* The strafe encoder ticks up when the robot moves to the left.
 
 ### 3. Localizer Tuning
 


### PR DESCRIPTION
Documentation states that teams should move their robot to the the right and see a positive increase in the sideways encoder value. However, the left direction is actually the positive x direction. Fixes this mistake in the documentation for two-wheel, three-wheel, and IMU three-wheel localiser pages.